### PR TITLE
fix(mdns): use main application executor to avoid tasks created on a dead executor after it's shut down

### DIFF
--- a/kadb-mdns/src/androidMain/kotlin/com/flyfishxu/kadb/mdns/KadbMdnsAndroid.kt
+++ b/kadb-mdns/src/androidMain/kotlin/com/flyfishxu/kadb/mdns/KadbMdnsAndroid.kt
@@ -12,8 +12,6 @@ import com.flyfishxu.kadb.mdns.internal.MdnsServiceKey
 import com.flyfishxu.kadb.mdns.internal.toMdnsEndpoint
 import com.flyfishxu.kadb.mdns.internal.toMdnsServiceKey
 import kotlinx.coroutines.flow.StateFlow
-import java.util.concurrent.ExecutorService
-import java.util.concurrent.Executors
 
 class KadbMdnsAndroid(
     context: Context,
@@ -22,7 +20,6 @@ class KadbMdnsAndroid(
     private val applicationContext = context.applicationContext
     private val nsdManager = applicationContext.getSystemService(NsdManager::class.java)
     private val registry = MdnsRegistry(config)
-    private val callbackExecutor: ExecutorService = Executors.newSingleThreadExecutor()
     private val callbacks = mutableMapOf<MdnsServiceKey, NsdManager.ServiceInfoCallback>()
     private val lock = Any()
     private var started = false
@@ -88,16 +85,8 @@ class KadbMdnsAndroid(
 
     override fun close() {
         stop()
-        val shouldShutdown = synchronized(lock) {
-            if (closed) {
-                false
-            } else {
-                closed = true
-                true
-            }
-        }
-        if (shouldShutdown) {
-            callbackExecutor.shutdownNow()
+        synchronized(lock) {
+            closed = true
         }
     }
 
@@ -178,7 +167,7 @@ class KadbMdnsAndroid(
         if (!shouldRegister) return
 
         runCatching {
-            nsdManager.registerServiceInfoCallback(serviceInfo, callbackExecutor, callback)
+            nsdManager.registerServiceInfoCallback(serviceInfo, applicationContext.mainExecutor, callback)
         }.onFailure {
             synchronized(lock) {
                 callbacks.remove(key, callback)


### PR DESCRIPTION
Fixes a crash:

```
java.util.concurrent.RejectedExecutionException: Task android.net.nsd.NsdManager$ServiceHandler$$ExternalSyntheticLambda8@395c41c rejected from java.util.concurrent.ThreadPoolExecutor@22d3825[Terminated, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 2]
                                         	at java.util.concurrent.ThreadPoolExecutor$AbortPolicy.rejectedExecution(ThreadPoolExecutor.java:2082)
                                         	at java.util.concurrent.ThreadPoolExecutor.reject(ThreadPoolExecutor.java:842)
                                         	at java.util.concurrent.ThreadPoolExecutor.execute(ThreadPoolExecutor.java:1374)
                                         	at java.util.concurrent.Executors$DelegatedExecutorService.execute(Executors.java:678)
                                         	at android.net.nsd.NsdManager$ServiceHandler.handleMessage(NsdManager.java:1144)
                                         	at android.os.Handler.dispatchMessage(Handler.java:109)
                                         	at android.os.Looper.loopOnce(Looper.java:232)
                                         	at android.os.Looper.loop(Looper.java:317)
                                         	at android.os.HandlerThread.run(HandlerThread.java:85)
```

After closing a `KadbMdnsAndroid` session.