### PR TITLE
fix: harden ADB transfers and failure paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,18 @@ Kadb.create("127.0.0.1", 5555).use { kadb ->
 }
 ```
 
+For large transfers over a higher-latency Wi-Fi link, opt in to ADB delayed acknowledgements:
+
+```kotlin
+val options = KadbOptions(delayedAckMode = DelayedAckMode.ENABLED)
+Kadb.create("192.168.1.20", 5555, options = options).use { kadb ->
+    kadb.push(largeFile, "/data/local/tmp/large.bin")
+}
+```
+
+The peer must also advertise `delayed_ack`. `AOSP_DEFAULT` follows adb's host policy: the JVM target
+uses `ADB_BURST_MODE=1`, while Android leaves the feature disabled unless explicitly enabled.
+
 Forward a TCP port:
 
 ```kotlin

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,13 +2,15 @@
 org.gradle.jvmargs=-XX:+UseParallelGC -Dfile.encoding=UTF-8
 org.gradle.caching=true
 org.gradle.parallel=true
-org.gradle.configuration-cache=true
+# Kotlin 2.4.0's KMP dependency checker is not serializable with Gradle 9.4.0.
+# Re-enable after the upstream toolchain supports configuration-cache storage.
+org.gradle.configuration-cache=false
 # Kotlin
 kotlin.code.style=official
 # Android
 android.useAndroidX=true
 android.nonTransitiveRClass=true
-android.enableConfigurationCache=true
+android.enableConfigurationCache=false
 android.builtInKotlin=false
 android.newDsl=false
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2EnabledWithHelpers

--- a/kadb-mdns/src/jvmMain/kotlin/com/flyfishxu/kadb/mdns/KadbMdnsJvm.kt
+++ b/kadb-mdns/src/jvmMain/kotlin/com/flyfishxu/kadb/mdns/KadbMdnsJvm.kt
@@ -56,14 +56,27 @@ class KadbMdnsJvm(
             return
         }
 
-        val newRegistrations = buildList {
+        val newRegistrations = mutableListOf<Registration>()
+        try {
             createdBackends.forEach { backend ->
                 config.serviceTypes.forEach { serviceType ->
                     val listener = JvmMdnsServiceEvents(backend)
                     backend.addServiceListener(serviceType.dnsType, listener)
-                    add(Registration(backend, serviceType.dnsType, listener))
+                    newRegistrations += Registration(backend, serviceType.dnsType, listener)
                 }
             }
+        } catch (_: Throwable) {
+            newRegistrations.forEach { registration ->
+                runCatching {
+                    registration.backend.removeServiceListener(registration.type, registration.listener)
+                }
+            }
+            createdBackends.forEach { backend -> runCatching { backend.close() } }
+            synchronized(lock) {
+                started = false
+                registry.failed()
+            }
+            return
         }
 
         synchronized(lock) {

--- a/kadb-mdns/src/jvmTest/kotlin/com/flyfishxu/kadb/mdns/KadbMdnsJvmTest.kt
+++ b/kadb-mdns/src/jvmTest/kotlin/com/flyfishxu/kadb/mdns/KadbMdnsJvmTest.kt
@@ -46,4 +46,18 @@ class KadbMdnsJvmTest {
         assertEquals(MdnsServiceType.entries.map { it.dnsType }.toSet(), backend.removedListenerTypes)
         assertTrue(backend.closed)
     }
+
+    @Test
+    fun registrationFailureRollsBackListenersAndClosesBackend() {
+        val backend = FakeJmDnsBackend().apply {
+            failOnAddType = MdnsServiceType.TLS_CONNECT.dnsType
+        }
+        val mdns = KadbMdnsJvm(config = MdnsConfig(), backendFactory = { listOf(backend) })
+
+        mdns.start()
+
+        assertEquals(MdnsStatus.FAILED, mdns.state.value.status)
+        assertTrue(backend.closed)
+        assertTrue(backend.removedListenerTypes.isNotEmpty())
+    }
 }

--- a/kadb-mdns/src/jvmTest/kotlin/com/flyfishxu/kadb/mdns/internal/FakeJmDnsBackend.kt
+++ b/kadb-mdns/src/jvmTest/kotlin/com/flyfishxu/kadb/mdns/internal/FakeJmDnsBackend.kt
@@ -5,8 +5,10 @@ internal class FakeJmDnsBackend : JmDnsBackend {
     val removedListenerTypes = linkedSetOf<String>()
     var closed = false
         private set
+    var failOnAddType: String? = null
 
     override fun addServiceListener(type: String, listener: JmDnsServiceEvents) {
+        if (type == failOnAddType) error("Synthetic listener registration failure")
         listeners[type] = listener
     }
 

--- a/kadb/build.gradle.kts
+++ b/kadb/build.gradle.kts
@@ -53,6 +53,12 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask<*>>().con
     }
 }
 
+tasks.withType<org.gradle.api.tasks.testing.Test>().configureEach {
+    if (System.getenv("KADB_EMULATOR_TESTS") != "1") {
+        exclude("**/KadbEmulatorIntegrationTest*")
+    }
+}
+
 signing {
     useGpgCmd()
 }

--- a/kadb/src/androidMain/kotlin/com/flyfishxu/kadb/transport/PlainBlockingChannel.kt
+++ b/kadb/src/androidMain/kotlin/com/flyfishxu/kadb/transport/PlainBlockingChannel.kt
@@ -45,16 +45,25 @@ internal class PlainBlockingChannel private constructor(
         get() = socket.remoteSocketAddress as InetSocketAddress
 
     override suspend fun read(dst: ByteBuffer, timeout: Long, unit: TimeUnit): Int {
+        if (!dst.hasRemaining()) return 0
         val oldTimeout = socket.soTimeout
         try {
             socket.soTimeout = if (timeout > 0) unit.toMillis(timeout).coerceAtMost(Int.MAX_VALUE.toLong()).toInt() else 0
             val max = min(dst.remaining(), 64 * 1024)
-            val buffer = ByteArray(max)
-            val read = input.read(buffer)
+            val read = if (dst.hasArray()) {
+                input.read(dst.array(), dst.arrayOffset() + dst.position(), max)
+            } else {
+                val buffer = ByteArray(max)
+                val count = input.read(buffer)
+                if (count > 0) dst.put(buffer, 0, count)
+                count
+            }
             if (read <= 0) {
                 return -1
             }
-            dst.put(buffer, 0, read)
+            if (dst.hasArray()) {
+                dst.position(dst.position() + read)
+            }
             return read
         } finally {
             socket.soTimeout = oldTimeout
@@ -63,13 +72,14 @@ internal class PlainBlockingChannel private constructor(
 
     override suspend fun write(src: ByteBuffer, timeout: Long, unit: TimeUnit): Int {
         val max = min(src.remaining(), 64 * 1024)
-        val tmp = ByteArray(max)
-        val originalLimit = src.limit()
-        val originalPosition = src.position()
-        src.limit(originalPosition + max)
-        src.get(tmp)
-        src.limit(originalLimit)
-        output.write(tmp)
+        if (src.hasArray()) {
+            output.write(src.array(), src.arrayOffset() + src.position(), max)
+            src.position(src.position() + max)
+        } else {
+            val tmp = ByteArray(max)
+            src.get(tmp)
+            output.write(tmp)
+        }
         return max
     }
 

--- a/kadb/src/commonMain/kotlin/com/flyfishxu/kadb/Kadb.kt
+++ b/kadb/src/commonMain/kotlin/com/flyfishxu/kadb/Kadb.kt
@@ -89,14 +89,21 @@ class Kadb(
         return AdbPtyShellSession(AdbShellStream(open(service)))
     }
 
-    fun push(src: File, remotePath: String, mode: Int = readMode(src), lastModifiedMs: Long = src.lastModified()) =
-        push(src.source(), remotePath, mode, lastModifiedMs)
+    fun push(src: File, remotePath: String, mode: Int = readMode(src), lastModifiedMs: Long = src.lastModified()) {
+        src.source().use { source ->
+            push(source, remotePath, mode, lastModifiedMs)
+        }
+    }
 
     fun push(source: Source, remotePath: String, mode: Int, lastModifiedMs: Long) {
         openSync().use { it.send(source, remotePath, mode, lastModifiedMs) }
     }
 
-    fun pull(dst: File, remotePath: String) = pull(dst.sink(false), remotePath)
+    fun pull(dst: File, remotePath: String) {
+        dst.sink(false).use { sink ->
+            pull(sink, remotePath)
+        }
+    }
 
     fun pull(sink: Sink, remotePath: String) {
         openSync().use { it.recv(sink, remotePath) }
@@ -111,7 +118,9 @@ class Kadb(
 
     fun install(file: File, vararg options: String) {
         if (supportsFeature("cmd")) {
-            install(file.source(), file.length(), *options)
+            file.source().use { source ->
+                install(source, file.length(), *options)
+            }
         } else {
             pmInstall(file, *options)
         }
@@ -157,19 +166,37 @@ class Kadb(
     }
 
     fun installMultiple(apks: List<File>, vararg options: String) {
+        require(apks.isNotEmpty()) { "At least one APK is required" }
         val installOptions = nonBlankOptions(options)
         val sessionMode = installSessionMode()
         val sessionId = createInstallSession(apks.sumOf { it.length() }, installOptions, sessionMode)
-        val error = if (sessionMode.usesStreaming) {
-            apks.firstNotNullOfOrNull { apk ->
-                streamInstallWrite(apk, sessionId, sessionMode).takeIf { !it.startsWith("Success") }
+        val writeError = try {
+            if (sessionMode.usesStreaming) {
+                apks.firstNotNullOfOrNull { apk ->
+                    streamInstallWrite(apk, sessionId, sessionMode).takeIf { !it.startsWith("Success") }
+                }
+            } else {
+                apks.mapIndexedNotNull { index, apk ->
+                    pushAndWrite(apk, sessionId, index).takeIf { !it.startsWith("Success") }
+                }.firstOrNull()
             }
-        } else {
-            apks.mapIndexedNotNull { index, apk ->
-                pushAndWrite(apk, sessionId, index).takeIf { !it.startsWith("Success") }
-            }.firstOrNull()
+        } catch (error: Throwable) {
+            abandonSessionAfterFailure(sessionId, sessionMode, error)
+            throw error
         }
-        finalizeSession(sessionId, error, sessionMode)
+
+        if (writeError != null) {
+            val error = IOException("Install failed: $writeError")
+            abandonSessionAfterFailure(sessionId, sessionMode, error)
+            throw error
+        }
+
+        try {
+            finishSession(sessionId, "install-commit", sessionMode)
+        } catch (error: Throwable) {
+            abandonSessionAfterFailure(sessionId, sessionMode, error)
+            throw error
+        }
     }
 
     fun uninstall(packageName: String) {
@@ -182,7 +209,9 @@ class Kadb(
             listOf("pm", "uninstall", packageName)
         }
         val response = shell(buildShellCommand(command))
-        check(response.exitCode == 0) { "Uninstall failed: ${response.allOutput}" }
+        check(response.exitCode == 0 && response.allOutput.trimStart().startsWith("Success")) {
+            "Uninstall failed: ${response.allOutput}"
+        }
     }
 
     // AOSP non-abb install path opens exec:cmd services and applies shell escaping per argument.
@@ -320,7 +349,9 @@ class Kadb(
             apk.name,
             "-"
         ).use { stream ->
-            stream.sink.writeAll(apk.source())
+            apk.source().use { source ->
+                stream.sink.writeAll(source)
+            }
             stream.sink.flush()
             stream.source.readUtf8()
         }
@@ -363,8 +394,7 @@ class Kadb(
         runCatching { shell(buildDeleteDeviceFileCommand(remotePath)) }
     }
 
-    private fun finalizeSession(sessionId: String, error: String?, sessionMode: InstallSessionMode) {
-        val finalCommand = if (error == null) "install-commit" else "install-abandon"
+    private fun finishSession(sessionId: String, finalCommand: String, sessionMode: InstallSessionMode) {
         // AOSP finalizes sessions with install-commit/install-abandon on the same install command family.
         // https://android.googlesource.com/platform/packages/modules/adb/+/refs/heads/main/client/adb_install.cpp#653
         val output = when (sessionMode) {
@@ -378,7 +408,16 @@ class Kadb(
             }
         }
         check(output.startsWith("Success")) { "Failed to finalize session: $output" }
-        error?.let { throw IOException("Install failed: $it") }
+    }
+
+    private fun abandonSessionAfterFailure(
+        sessionId: String,
+        sessionMode: InstallSessionMode,
+        originalError: Throwable
+    ) {
+        runCatching {
+            finishSession(sessionId, "install-abandon", sessionMode)
+        }.exceptionOrNull()?.let(originalError::addSuppressed)
     }
 
     // Shell fallback builds one command string; mirror AOSP argv behavior by dropping empty args first.

--- a/kadb/src/commonMain/kotlin/com/flyfishxu/kadb/core/AdbConnection.kt
+++ b/kadb/src/commonMain/kotlin/com/flyfishxu/kadb/core/AdbConnection.kt
@@ -274,7 +274,7 @@ internal class AdbConnection internal constructor(
 
         private fun decodeOkayAckBytes(message: AdbMessage, delayedAckEnabled: Boolean): Int {
             require(message.command == AdbProtocol.CMD_OKAY) { "Expected OKAY message, got ${message.command}" }
-            return when (message.payloadLength) {
+            val ackBytes = when (message.payloadLength) {
                 0 -> {
                     if (delayedAckEnabled) {
                         throw IOException("Delayed ACK stream missing OKAY payload for localId: ${message.arg1.toString(16)}")
@@ -293,6 +293,10 @@ internal class AdbConnection internal constructor(
 
                 else -> throw IOException("Invalid OKAY payload size: ${message.payloadLength}")
             }
+            if (delayedAckEnabled && ackBytes <= 0) {
+                throw IOException("Invalid delayed ACK byte count: $ackBytes")
+            }
+            return ackBytes
         }
     }
 }

--- a/kadb/src/commonMain/kotlin/com/flyfishxu/kadb/forwarding/TcpForwarder.kt
+++ b/kadb/src/commonMain/kotlin/com/flyfishxu/kadb/forwarding/TcpForwarder.kt
@@ -22,7 +22,9 @@ import okio.*
 import java.io.IOException
 import java.io.InterruptedIOException
 import java.net.ServerSocket
+import java.net.Socket
 import java.net.SocketException
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
@@ -34,24 +36,34 @@ internal class TcpForwarder(
     private val hostPort: Int,
     private val targetPort: Int,
 ) : AutoCloseable {
+    private companion object {
+        const val FORWARD_BUFFER_SIZE = 64 * 1024L
+    }
 
+    @Volatile
     private var state: State = State.STOPPED
     private var serverThread: Thread? = null
     private var server: ServerSocket? = null
     private var clientExecutor: ExecutorService? = null
+    private val activeClients = ConcurrentHashMap.newKeySet<Socket>()
+    private val activeStreams = ConcurrentHashMap.newKeySet<com.flyfishxu.kadb.stream.AdbStream>()
+    @Volatile
+    private var startupError: Throwable? = null
 
     fun start() {
         check(state == State.STOPPED) { "Forwarder is already started at port $hostPort" }
 
         moveToState(State.STARTING)
+        startupError = null
 
         clientExecutor = Executors.newCachedThreadPool()
         serverThread = thread {
             try {
                 handleForwarding()
-            } catch (_: SocketException) {
-                // Do nothing
+            } catch (e: SocketException) {
+                if (state == State.STARTING) startupError = e
             } catch (e: IOException) {
+                if (state == State.STARTING) startupError = e
                 log { "could not start TCP port forwarding: ${e.message}" }
             } finally {
                 moveToState(State.STOPPED)
@@ -59,7 +71,13 @@ internal class TcpForwarder(
         }
 
         waitFor(10, 5000) {
-            state == State.STARTED
+            state == State.STARTED || state == State.STOPPED
+        }
+        if (state != State.STARTED) {
+            clientExecutor?.shutdownNow()
+            clientExecutor = null
+            serverThread = null
+            throw IOException("Could not start TCP port forwarding on port $hostPort", startupError)
         }
     }
 
@@ -71,12 +89,14 @@ internal class TcpForwarder(
 
         while (!Thread.interrupted()) {
             val client = serverRef.accept()
+            activeClients += client
 
             clientExecutor?.execute {
                 var adbStream: com.flyfishxu.kadb.stream.AdbStream? = null
                 var readerThread: Thread? = null
                 try {
                     adbStream = kadb.open("tcp:$targetPort")
+                    activeStreams += adbStream
                     val stream = adbStream
                     readerThread = thread {
                         try {
@@ -89,7 +109,9 @@ internal class TcpForwarder(
                         stream.source, client.sink().buffer()
                     )
                 } finally {
+                    adbStream?.let(activeStreams::remove)
                     adbStream?.close()
+                    activeClients.remove(client)
                     client.close()
                     readerThread?.interrupt()
                 }
@@ -105,18 +127,23 @@ internal class TcpForwarder(
         // Make sure that we are not stopping the server while it is in a transient state
         // to avoid surprises
         waitFor(10, 5000) {
-            state == State.STARTED
+            state != State.STARTING
         }
+        if (state == State.STOPPED) return
 
         moveToState(State.STOPPING)
 
         server?.close()
         server = null
+        activeClients.toList().forEach { runCatching { it.close() } }
+        activeStreams.toList().forEach { runCatching { it.close() } }
         serverThread?.interrupt()
         serverThread = null
-        clientExecutor?.shutdown()
+        clientExecutor?.shutdownNow()
         clientExecutor?.awaitTermination(5, TimeUnit.SECONDS)
         clientExecutor = null
+        activeClients.clear()
+        activeStreams.clear()
 
         waitFor(10, 5000) {
             state == State.STOPPED
@@ -127,7 +154,7 @@ internal class TcpForwarder(
         try {
             while (!Thread.interrupted()) {
                 try {
-                    if (source.read(sink.buffer, 256) >= 0) {
+                    if (source.read(sink.buffer, FORWARD_BUFFER_SIZE) >= 0) {
                         sink.flush()
                     } else {
                         return

--- a/kadb/src/commonMain/kotlin/com/flyfishxu/kadb/stream/AdbStream.kt
+++ b/kadb/src/commonMain/kotlin/com/flyfishxu/kadb/stream/AdbStream.kt
@@ -41,6 +41,7 @@ class AdbStream internal constructor(
         private var bytesRead = 0
 
         override fun read(sink: Buffer, byteCount: Long): Long {
+            if (byteCount == 0L) return 0L
             val message = message() ?: return -1
 
             val bytesRemaining = message.payloadLength - bytesRead
@@ -53,15 +54,15 @@ class AdbStream internal constructor(
             sink.write(message.payload, bytesRead, bytesToRead)
 
             bytesRead += bytesToRead
-            if (delayedAckEnabled && bytesToRead > 0) {
-                adbWriter.writeOkay(localId, remoteId, bytesToRead)
-            }
-
             check(bytesRead <= message.payloadLength)
 
             if (bytesRead == message.payloadLength) {
                 this.message = null
-                if (!delayedAckEnabled) {
+                if (delayedAckEnabled) {
+                    if (message.payloadLength > 0) {
+                        adbWriter.writeOkay(localId, remoteId, message.payloadLength)
+                    }
+                } else {
                     adbWriter.writeOkay(localId, remoteId)
                 }
             }
@@ -111,7 +112,7 @@ class AdbStream internal constructor(
             val payloadLength = buffer.position()
             if (payloadLength == 0) return
             if (delayedAckEnabled) {
-                while (availableSendBytes <= 0) {
+                while (availableSendBytes < payloadLength) {
                     availableSendBytes += awaitAckBytes().toLong()
                 }
             }
@@ -133,7 +134,11 @@ class AdbStream internal constructor(
     private fun awaitAckBytes(): Int {
         val message = nextMessage(AdbProtocol.CMD_OKAY)
             ?: throw IOException("ADB stream closed before delayed ACK for localId: ${localId.toString(16)}")
-        return decodeOkayAckBytes(message)
+        return decodeOkayAckBytes(message).also { ackBytes ->
+            if (ackBytes <= 0) {
+                throw IOException("Invalid delayed ACK byte count: $ackBytes")
+            }
+        }
     }
 
     private fun decodeOkayAckBytes(message: AdbMessage): Int {

--- a/kadb/src/commonMain/kotlin/com/flyfishxu/kadb/stream/AdbSyncStream.kt
+++ b/kadb/src/commonMain/kotlin/com/flyfishxu/kadb/stream/AdbSyncStream.kt
@@ -102,6 +102,7 @@ class AdbSyncStream(
 ) : AutoCloseable {
 
     private val buffer = Buffer()
+    private var closed = false
     private val isWindowsHost =
         System.getProperty("os.name")?.startsWith("Windows", ignoreCase = true) == true
 
@@ -515,7 +516,12 @@ class AdbSyncStream(
     private fun readUInt32AsLong(): Long = stream.source.readIntLe().toLong() and 0xFFFF_FFFFL
 
     override fun close() {
-        writePacket(ID_QUIT, 0)
-        stream.close()
+        if (closed) return
+        closed = true
+        try {
+            writePacket(ID_QUIT, 0)
+        } finally {
+            stream.close()
+        }
     }
 }

--- a/kadb/src/commonMain/kotlin/com/flyfishxu/kadb/transport/OkioAdapters.kt
+++ b/kadb/src/commonMain/kotlin/com/flyfishxu/kadb/transport/OkioAdapters.kt
@@ -90,9 +90,9 @@ internal fun TransportChannel.asOkioSink(writeTimeoutMs: Long = 0L): Sink = obje
             val copied = source.read(array, offset, toWrite)
             require(copied > 0) { "Unexpected EOF while reading from buffer" }
 
-            scratch.clear()
-            scratch.put(array, offset, copied)
-            scratch.flip()
+            // Buffer.read() filled the backing array directly; only expose the written range.
+            scratch.position(0)
+            scratch.limit(copied)
             runBlocking { writeExactly(scratch, writeTimeoutMs, TimeUnit.MILLISECONDS) }
             remaining -= copied
         }

--- a/kadb/src/jvmTest/kotlin/com/flyfishxu/kadb/KadbDelayedAckTest.kt
+++ b/kadb/src/jvmTest/kotlin/com/flyfishxu/kadb/KadbDelayedAckTest.kt
@@ -1,0 +1,241 @@
+package com.flyfishxu.kadb
+
+import java.io.ByteArrayOutputStream
+import java.io.DataInputStream
+import java.io.File
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.net.SocketTimeoutException
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.thread
+import kotlin.io.path.createTempDirectory
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class KadbDelayedAckTest {
+    @Test
+    fun delayedAckWaitsForEnoughWindowBeforeSendingNextPayload() {
+        val expected = ByteArray(1024 * 1024) { index -> ((index * 31 + 17) and 0xff).toByte() }
+        val tempDir = createTempDirectory("kadb-delayed-ack").toFile()
+        val source = File(tempDir, "source.bin").apply { writeBytes(expected) }
+        val received = AtomicReference<ByteArray?>(null)
+        val serverFailure = AtomicReference<Throwable?>(null)
+
+        try {
+            ServerSocket(0, 1, InetAddress.getLoopbackAddress()).use { server ->
+                val serverThread = thread(name = "kadb-delayed-ack-peer") {
+                    try {
+                        server.accept().use { socket ->
+                            socket.soTimeout = IO_TIMEOUT_MS
+                            val input = DataInputStream(socket.getInputStream().buffered())
+                            val output = socket.getOutputStream().buffered()
+
+                            val connect = readPacket(input)
+                            check(connect.command == CMD_CNXN)
+                            writePacket(
+                                output,
+                                CMD_CNXN,
+                                ADB_VERSION,
+                                ADB_MAX_DATA,
+                                "device::features=delayed_ack,sendrecv_v2".encodeToByteArray()
+                            )
+
+                            val open = readPacket(input)
+                            check(open.command == CMD_OPEN)
+                            val clientId = open.arg0
+                            val serverId = 1
+                            writePacket(output, CMD_OKAY, serverId, clientId, littleEndianInt(INITIAL_WINDOW))
+
+                            val syncBytes = ByteArrayOutputStream()
+                            var firstWrite = true
+                            var parsed: ParsedSync? = null
+                            while (parsed == null) {
+                                val write = readPacket(input)
+                                check(write.command == CMD_WRTE)
+                                syncBytes.write(write.payload)
+
+                                if (firstWrite) {
+                                    firstWrite = false
+                                    socket.soTimeout = WINDOW_PROBE_TIMEOUT_MS
+                                    try {
+                                        val premature = readPacket(input)
+                                        error(
+                                            "Client exceeded delayed-ACK window before credit arrived: " +
+                                                "command=${premature.command.toString(16)} bytes=${premature.payload.size}"
+                                        )
+                                    } catch (_: SocketTimeoutException) {
+                                    // Expected: the setup WRTE leaves less credit than the next DATA WRTE needs.
+                                    } finally {
+                                        socket.soTimeout = IO_TIMEOUT_MS
+                                    }
+                                }
+
+                                writePacket(
+                                    output,
+                                    CMD_OKAY,
+                                    serverId,
+                                    clientId,
+                                    littleEndianInt(write.payload.size)
+                                )
+                                parsed = parseCompletedSend(syncBytes.toByteArray())
+                            }
+
+                            received.set(parsed.data)
+                            writePacket(output, CMD_WRTE, serverId, clientId, syncOkay())
+
+                            while (true) {
+                                val packet = readPacket(input)
+                                when (packet.command) {
+                                    CMD_OKAY -> Unit
+                                    CMD_WRTE -> writePacket(
+                                        output,
+                                        CMD_OKAY,
+                                        serverId,
+                                        clientId,
+                                        littleEndianInt(packet.payload.size)
+                                    )
+
+                                    CMD_CLSE -> {
+                                        writePacket(output, CMD_CLSE, serverId, clientId)
+                                        break
+                                    }
+
+                                    else -> error("Unexpected command: ${packet.command.toString(16)}")
+                                }
+                            }
+                        }
+                    } catch (error: Throwable) {
+                        serverFailure.set(error)
+                    }
+                }
+
+                var clientFailure: Throwable? = null
+                try {
+                    Kadb.create(
+                        host = "127.0.0.1",
+                        port = server.localPort,
+                        connectTimeout = IO_TIMEOUT_MS,
+                        socketTimeout = IO_TIMEOUT_MS,
+                        options = KadbOptions(DelayedAckMode.ENABLED)
+                    ).use { kadb ->
+                        kadb.push(source, "/data/local/tmp/source.bin")
+                    }
+                } catch (error: Throwable) {
+                    clientFailure = error
+                }
+
+                serverThread.join(IO_TIMEOUT_MS.toLong())
+                assertEquals(false, serverThread.isAlive, "Synthetic delayed-ACK peer did not finish")
+                assertNull(serverFailure.get(), serverFailure.get()?.stackTraceToString())
+                assertNull(clientFailure, clientFailure?.stackTraceToString())
+                assertContentEquals(expected, checkNotNull(received.get()))
+            }
+        } finally {
+            tempDir.deleteRecursively()
+        }
+    }
+
+    private fun parseCompletedSend(bytes: ByteArray): ParsedSync? {
+        val buffer = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN)
+        if (buffer.remaining() < 8) return null
+        check(buffer.readId() == "SND2")
+        val pathLength = buffer.int
+        if (pathLength < 0 || buffer.remaining() < pathLength + 12) return null
+        buffer.position(buffer.position() + pathLength)
+        check(buffer.readId() == "SND2")
+        buffer.int // mode
+        buffer.int // flags
+
+        val data = ByteArrayOutputStream()
+        while (buffer.remaining() >= 8) {
+            val id = buffer.readId()
+            val argument = buffer.int
+            when (id) {
+                "DATA" -> {
+                    if (argument < 0 || buffer.remaining() < argument) return null
+                    val chunk = ByteArray(argument)
+                    buffer.get(chunk)
+                    data.write(chunk)
+                }
+
+                "DONE" -> return ParsedSync(data.toByteArray())
+                else -> error("Unexpected sync id: $id")
+            }
+        }
+        return null
+    }
+
+    private fun readPacket(input: DataInputStream): AdbPacket {
+        val command = input.readIntLe()
+        val arg0 = input.readIntLe()
+        val arg1 = input.readIntLe()
+        val length = input.readIntLe()
+        input.readIntLe() // checksum
+        val magic = input.readIntLe()
+        check(magic == command.inv())
+        check(length in 0..ADB_MAX_DATA)
+        return AdbPacket(command, arg0, arg1, input.readNBytes(length))
+    }
+
+    private fun writePacket(
+        output: java.io.OutputStream,
+        command: Int,
+        arg0: Int,
+        arg1: Int,
+        payload: ByteArray = ByteArray(0)
+    ) {
+        val packet = ByteBuffer.allocate(24 + payload.size)
+            .order(ByteOrder.LITTLE_ENDIAN)
+            .putInt(command)
+            .putInt(arg0)
+            .putInt(arg1)
+            .putInt(payload.size)
+            .putInt(0)
+            .putInt(command.inv())
+            .put(payload)
+            .array()
+        output.write(packet)
+        output.flush()
+    }
+
+    private fun DataInputStream.readIntLe(): Int = Integer.reverseBytes(readInt())
+
+    private fun ByteBuffer.readId(): String {
+        val id = ByteArray(4)
+        get(id)
+        return id.decodeToString()
+    }
+
+    private fun littleEndianInt(value: Int): ByteArray = ByteBuffer.allocate(Int.SIZE_BYTES)
+        .order(ByteOrder.LITTLE_ENDIAN)
+        .putInt(value)
+        .array()
+
+    private fun syncOkay(): ByteArray = ByteBuffer.allocate(8)
+        .order(ByteOrder.LITTLE_ENDIAN)
+        .put("OKAY".encodeToByteArray())
+        .putInt(0)
+        .array()
+
+    private data class AdbPacket(val command: Int, val arg0: Int, val arg1: Int, val payload: ByteArray)
+    private data class ParsedSync(val data: ByteArray)
+
+    private companion object {
+        const val CMD_CNXN = 0x4e584e43
+        const val CMD_OPEN = 0x4e45504f
+        const val CMD_OKAY = 0x59414b4f
+        const val CMD_CLSE = 0x45534c43
+        const val CMD_WRTE = 0x45545257
+        const val ADB_VERSION = 0x01000001
+        const val ADB_MAX_DATA = 1024 * 1024
+        // Large enough for an 8,200-byte DATA WRTE, but not for that packet plus the
+        // preceding 46-byte SND2 setup WRTE. This exposes partial-window oversends.
+        const val INITIAL_WINDOW = 8_224
+        const val IO_TIMEOUT_MS = 5_000
+        const val WINDOW_PROBE_TIMEOUT_MS = 250
+    }
+}

--- a/kadb/src/jvmTest/kotlin/com/flyfishxu/kadb/KadbEmulatorIntegrationTest.kt
+++ b/kadb/src/jvmTest/kotlin/com/flyfishxu/kadb/KadbEmulatorIntegrationTest.kt
@@ -1,0 +1,263 @@
+package com.flyfishxu.kadb
+
+import com.flyfishxu.kadb.cert.KadbCert
+import com.flyfishxu.kadb.cert.OkioFilePrivateKeyStore
+import com.flyfishxu.kadb.shell.AdbShellPacket
+import okio.Path.Companion.toPath
+import okio.source
+import java.io.File
+import java.net.ServerSocket
+import java.net.Socket
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.security.MessageDigest
+import kotlin.io.path.createTempDirectory
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class KadbEmulatorIntegrationTest {
+    private val enabled = System.getenv("KADB_EMULATOR_TESTS") == "1"
+    private val host = System.getenv("KADB_TEST_HOST") ?: "127.0.0.1"
+    private val port = System.getenv("KADB_TEST_PORT")?.toIntOrNull() ?: 15555
+
+    @Test
+    fun connectionShellInteractiveShellAndPty() = withEmulator {
+        newClient().use { kadb ->
+            assertFalse(kadb.connectionCheck())
+
+            val response = kadb.shell("printf stdout; printf stderr >&2; exit 7")
+            assertEquals("stdout", response.output)
+            assertEquals("stderr", response.errorOutput)
+            assertEquals(7, response.exitCode)
+            assertTrue(kadb.connectionCheck())
+            assertTrue(kadb.supportsFeature("shell_v2"))
+
+            kadb.openShell("cat").use { shell ->
+                shell.write("interactive-shell\n")
+                shell.closeStdin()
+                assertEquals("interactive-shell\n", shell.readAll().output)
+            }
+
+            kadb.openPtyShellSession("cat").use { pty ->
+                pty.resize(rows = 40, cols = 120)
+                pty.write("pty-shell\n")
+                pty.closeStdin()
+                val stdout = StringBuilder()
+                while (true) {
+                    when (val packet = pty.read()) {
+                        is AdbShellPacket.StdOut -> stdout.append(packet.payload.decodeToString())
+                        is AdbShellPacket.StdError -> Unit
+                        is AdbShellPacket.Exit -> break
+                    }
+                }
+                assertTrue(stdout.contains("pty-shell"))
+            }
+
+            kadb.resetConnection()
+            assertFalse(kadb.connectionCheck())
+            assertEquals("reconnected\n", kadb.shell("echo reconnected").output)
+        }
+
+        assertNotNull(Kadb.tryConnection(host, port, enabledOptions())).close()
+    }
+
+    @Test
+    fun syncMetadataAndLargeFileRoundTripWithClassicAndDelayedAcks() = withEmulator {
+        val tempDir = createTempDirectory("kadb-large-transfer").toFile()
+        try {
+            val source = File(tempDir, "source.bin")
+            val pulled = File(tempDir, "pulled.bin")
+            createPatternFile(source, largeFileBytes())
+            val expectedDigest = sha256(source)
+
+            for (mode in listOf(DelayedAckMode.DISABLED, DelayedAckMode.ENABLED)) {
+                val remote = "/data/local/tmp/kadb-${mode.name.lowercase()}.bin"
+                Kadb.create(
+                    host = host,
+                    port = port,
+                    connectTimeout = 10_000,
+                    socketTimeout = 60_000,
+                    options = KadbOptions(mode)
+                ).use { kadb ->
+                    val pushStart = System.nanoTime()
+                    kadb.push(source, remote)
+                    val pushSeconds = elapsedSeconds(pushStart)
+
+                    kadb.openSync().use { sync ->
+                        val stat = sync.lstat(remote)
+                        assertEquals(source.length(), stat.size)
+                        assertTrue(sync.list("/data/local/tmp").any { it.name == File(remote).name })
+                        if (kadb.supportsFeature("stat_v2")) {
+                            assertEquals(source.length(), sync.statV2(remote).size)
+                        }
+                    }
+
+                    val deviceDigest = kadb.shell("sha256sum '$remote' | cut -d' ' -f1").output.trim()
+                    assertEquals(expectedDigest, deviceDigest)
+
+                    val pullStart = System.nanoTime()
+                    kadb.pull(pulled, remote)
+                    val pullSeconds = elapsedSeconds(pullStart)
+                    assertEquals(expectedDigest, sha256(pulled))
+
+                    println(
+                        "Kadb ${mode.name}: push=${mbps(source.length(), pushSeconds)} MiB/s, " +
+                            "pull=${mbps(source.length(), pullSeconds)} MiB/s, bytes=${source.length()}"
+                    )
+                    kadb.shell("rm -f '$remote'")
+                }
+            }
+        } finally {
+            tempDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun streamedFileAndSplitSessionInstallThenUninstall() = withEmulator {
+        val apk = File(requireEnv("KADB_TEST_APK"))
+        val packageName = requireEnv("KADB_TEST_PACKAGE")
+        assertTrue(apk.isFile)
+
+        newClient().use { kadb ->
+            kadb.install(apk, "-r")
+            assertPackageInstalled(kadb, packageName)
+
+            apk.source().use { source ->
+                kadb.install(source, apk.length(), "-r")
+            }
+            assertPackageInstalled(kadb, packageName)
+
+            kadb.installMultiple(listOf(apk), "-r")
+            assertPackageInstalled(kadb, packageName)
+
+            val execOutput = kadb.execCmd("package", "path", packageName).use { it.source.readUtf8() }
+            assertTrue(execOutput.contains("package:"))
+
+            if (kadb.supportsFeature("abb_exec")) {
+                val abbOutput = kadb.abbExec("package", "path", packageName).use { it.source.readUtf8() }
+                assertTrue(abbOutput.contains("package:"))
+            }
+
+            kadb.uninstall(packageName)
+            assertFalse(kadb.shell("pm path '$packageName'").output.contains("package:"))
+        }
+    }
+
+    @Test
+    fun tcpForwardCarriesBidirectionalAdbTraffic() = withEmulator {
+        val targetPort = System.getenv("KADB_TEST_DEVICE_ADBD_PORT")?.toIntOrNull() ?: 5555
+        val hostPort = ServerSocket(0).use { it.localPort }
+
+        newClient().use { kadb ->
+            kadb.tcpForward(hostPort, targetPort).use {
+                Socket("127.0.0.1", hostPort).use { socket ->
+                    socket.soTimeout = 10_000
+                    socket.getOutputStream().write(connectPacket())
+                    socket.getOutputStream().flush()
+
+                    val header = socket.getInputStream().readNBytes(24)
+                    assertEquals(24, header.size)
+                    val command = ByteBuffer.wrap(header).order(ByteOrder.LITTLE_ENDIAN).int
+                    assertTrue(command == CMD_AUTH || command == CMD_CNXN)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun emptyInstallSetIsRejectedBeforeConnecting() = withEmulator {
+        newClient().use { kadb ->
+            val error = runCatching { kadb.installMultiple(emptyList()) }.exceptionOrNull()
+            assertTrue(error is IllegalArgumentException)
+        }
+    }
+
+    private fun newClient(): Kadb = Kadb.create(
+        host = host,
+        port = port,
+        connectTimeout = 10_000,
+        socketTimeout = 60_000,
+        options = enabledOptions()
+    )
+
+    private fun enabledOptions() = KadbOptions(DelayedAckMode.ENABLED)
+
+    private fun withEmulator(block: () -> Unit) {
+        if (!enabled) return
+        configureAuthorizedIdentity()
+        block()
+    }
+
+    private fun configureAuthorizedIdentity() {
+        synchronized(identityLock) {
+            val keyPath = requireEnv("KADB_TEST_ADBKEY").toPath()
+            KadbCert.configure(OkioFilePrivateKeyStore(keyPath))
+            KadbCert.ensureReady()
+        }
+    }
+
+    private fun assertPackageInstalled(kadb: Kadb, packageName: String) {
+        assertTrue(kadb.shell("pm path '$packageName'").output.contains("package:"))
+    }
+
+    private fun createPatternFile(file: File, byteCount: Long) {
+        val block = ByteArray(1024 * 1024) { index -> ((index * 31 + 17) and 0xff).toByte() }
+        file.outputStream().buffered().use { output ->
+            var remaining = byteCount
+            while (remaining > 0) {
+                val count = minOf(block.size.toLong(), remaining).toInt()
+                output.write(block, 0, count)
+                remaining -= count
+            }
+        }
+    }
+
+    private fun sha256(file: File): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        file.inputStream().buffered().use { input ->
+            val buffer = ByteArray(1024 * 1024)
+            while (true) {
+                val read = input.read(buffer)
+                if (read < 0) break
+                digest.update(buffer, 0, read)
+            }
+        }
+        return digest.digest().joinToString("") { "%02x".format(it) }
+    }
+
+    private fun connectPacket(): ByteArray {
+        val payload = "host::features=shell_v2".encodeToByteArray()
+        val checksum = payload.sumOf { it.toUByte().toInt() }
+        return ByteBuffer.allocate(24 + payload.size)
+            .order(ByteOrder.LITTLE_ENDIAN)
+            .putInt(CMD_CNXN)
+            .putInt(0x01000001)
+            .putInt(1024 * 1024)
+            .putInt(payload.size)
+            .putInt(checksum)
+            .putInt(CMD_CNXN.inv())
+            .put(payload)
+            .array()
+    }
+
+    private fun largeFileBytes(): Long =
+        System.getenv("KADB_LARGE_FILE_BYTES")?.toLongOrNull() ?: 64L * 1024 * 1024
+
+    private fun elapsedSeconds(startNanos: Long): Double =
+        (System.nanoTime() - startNanos) / 1_000_000_000.0
+
+    private fun mbps(bytes: Long, seconds: Double): String =
+        "%.2f".format((bytes / 1024.0 / 1024.0) / seconds)
+
+    private fun requireEnv(name: String): String =
+        requireNotNull(System.getenv(name)) { "Missing environment variable: $name" }
+
+    private companion object {
+        val identityLock = Any()
+        const val CMD_AUTH = 0x48545541
+        const val CMD_CNXN = 0x4e584e43
+    }
+}

--- a/kadb/src/jvmTest/kotlin/com/flyfishxu/kadb/KadbResourceTest.kt
+++ b/kadb/src/jvmTest/kotlin/com/flyfishxu/kadb/KadbResourceTest.kt
@@ -1,0 +1,79 @@
+package com.flyfishxu.kadb
+
+import java.io.File
+import java.io.IOException
+import java.net.InetAddress
+import java.net.ServerSocket
+import kotlin.concurrent.thread
+import kotlin.io.path.createTempDirectory
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class KadbResourceTest {
+    @Test
+    fun emptyInstallSetIsRejectedWithoutOpeningAConnection() {
+        Kadb.create("127.0.0.1", 1).use { kadb ->
+            assertFailsWith<IllegalArgumentException> {
+                kadb.installMultiple(emptyList())
+            }
+        }
+    }
+
+    @Test
+    fun failedFileTransfersDoNotLeakLocalFileDescriptors() {
+        val procFileDescriptors = File("/proc/self/fd")
+        if (!procFileDescriptors.isDirectory) return
+
+        val tempDir = createTempDirectory("kadb-resource-test").toFile()
+        val source = File(tempDir, "source.bin").apply { writeBytes(ByteArray(1024) { it.toByte() }) }
+        val destination = File(tempDir, "destination.bin")
+        val attemptsPerDirection = 24
+        val totalConnections = 1 + attemptsPerDirection * 2
+
+        ServerSocket(0, 50, InetAddress.getLoopbackAddress()).use { server ->
+            val acceptThread = thread(name = "kadb-failing-peer") {
+                repeat(totalConnections) {
+                    server.accept().use { socket ->
+                        socket.getInputStream().read(ByteArray(24))
+                    }
+                }
+            }
+
+            Kadb.create("127.0.0.1", server.localPort, connectTimeout = 2_000, socketTimeout = 2_000).use { kadb ->
+                runCatching { kadb.push(source, "/data/local/tmp/warmup.bin") }
+                val before = descriptorCount(procFileDescriptors)
+
+                repeat(attemptsPerDirection) {
+                    runCatching { kadb.push(source, "/data/local/tmp/source.bin") }
+                }
+                repeat(attemptsPerDirection) {
+                    runCatching { kadb.pull(destination, "/data/local/tmp/source.bin") }
+                }
+
+                val leaked = descriptorCount(procFileDescriptors) - before
+                assertTrue(leaked <= 4, "Failed transfers leaked $leaked file descriptors")
+            }
+
+            acceptThread.join(10_000)
+            assertTrue(!acceptThread.isAlive, "Synthetic ADB peer did not finish")
+        }
+        tempDir.deleteRecursively()
+    }
+
+    @Test
+    fun tcpForwardReportsBindFailureWithoutWaitingForTimeout() {
+        ServerSocket(0, 1, InetAddress.getLoopbackAddress()).use { occupiedPort ->
+            Kadb.create("127.0.0.1", 1).use { kadb ->
+                val start = System.nanoTime()
+                assertFailsWith<IOException> {
+                    kadb.tcpForward(occupiedPort.localPort, targetPort = 12345)
+                }
+                val elapsedMs = (System.nanoTime() - start) / 1_000_000
+                assertTrue(elapsedMs < 2_000, "Bind failure took ${elapsedMs}ms to surface")
+            }
+        }
+    }
+
+    private fun descriptorCount(directory: File): Int = directory.list()?.size ?: 0
+}

--- a/kadb/src/jvmTest/resources/AndroidManifest.xml
+++ b/kadb/src/jvmTest/resources/AndroidManifest.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.flyfishxu.kadb.integrationfixture">
+    <uses-sdk android:minSdkVersion="23" android:targetSdkVersion="35" />
+    <application android:label="Kadb Integration Fixture" />
+</manifest>

--- a/scripts/run-emulator-integration.sh
+++ b/scripts/run-emulator-integration.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly DEVICE_ADBD_PORT=5555
+readonly HOST_ADBD_PORT=15555
+readonly TEST_PACKAGE=com.flyfishxu.kadb.integrationfixture
+readonly WORK_DIR="${RUNNER_TEMP:-/tmp}/kadb-emulator-integration"
+
+mkdir -p "$WORK_DIR"
+
+adb wait-for-device
+adb tcpip "$DEVICE_ADBD_PORT"
+adb wait-for-device
+adb forward --remove "tcp:$HOST_ADBD_PORT" 2>/dev/null || true
+adb forward "tcp:$HOST_ADBD_PORT" "tcp:$DEVICE_ADBD_PORT"
+
+build_tools_dir="$ANDROID_SDK_ROOT/build-tools/$(ls "$ANDROID_SDK_ROOT/build-tools" | sort -V | tail -n 1)"
+platform_jar="$ANDROID_SDK_ROOT/platforms/android-35/android.jar"
+unsigned_apk="$WORK_DIR/integration-fixture-unsigned.apk"
+signed_apk="$WORK_DIR/integration-fixture.apk"
+keystore="$WORK_DIR/integration-fixture.jks"
+
+"$build_tools_dir/aapt2" link \
+  -I "$platform_jar" \
+  --manifest "kadb/src/jvmTest/resources/AndroidManifest.xml" \
+  -o "$unsigned_apk"
+
+keytool -genkeypair -noprompt \
+  -keystore "$keystore" \
+  -storepass android \
+  -keypass android \
+  -alias androiddebugkey \
+  -dname "CN=Kadb Integration Test,O=Kadb,C=US" \
+  -keyalg RSA \
+  -keysize 2048 \
+  -validity 10000
+
+"$build_tools_dir/apksigner" sign \
+  --ks "$keystore" \
+  --ks-pass pass:android \
+  --key-pass pass:android \
+  --out "$signed_apk" \
+  "$unsigned_apk"
+
+export KADB_EMULATOR_TESTS=1
+export KADB_TEST_HOST=127.0.0.1
+export KADB_TEST_PORT="$HOST_ADBD_PORT"
+export KADB_TEST_DEVICE_ADBD_PORT="$DEVICE_ADBD_PORT"
+export KADB_TEST_ADBKEY="${ANDROID_USER_HOME:-$HOME/.android}/adbkey"
+export KADB_TEST_APK="$signed_apk"
+export KADB_TEST_PACKAGE="$TEST_PACKAGE"
+export KADB_LARGE_FILE_BYTES="${KADB_LARGE_FILE_BYTES:-67108864}"
+
+"${GRADLE_BIN:-./gradlew}" :kadb:jvmTest \
+  -PsignAllPublications=false \
+  --tests com.flyfishxu.kadb.KadbEmulatorIntegrationTest

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,10 +16,6 @@ dependencyResolutionManagement {
     }
 }
 
-plugins {
-    id("de.fayard.refreshVersions") version "0.60.6"
-}
-
 rootProject.name = "Kadb"
 include(":kadb")
 include(":kadb-mdns")


### PR DESCRIPTION
## Summary

This draft hardens Kadb's transfer, forwarding, installation, and mDNS failure paths and adds local regression/integration coverage.

### Large-transfer root causes fixed

- **Delayed-ACK window oversend:** the writer previously sent a whole WRTE whenever any credit remained. A payload larger than the remaining receive window could therefore be sent prematurely, causing stalls or disconnects. It now waits until credit covers the complete payload.
- **ACK amplification:** reads smaller than one WRTE emitted an OKAY for every partial Okio read. Credit is now returned once after the WRTE is fully consumed.
- **Android allocation/copy pressure:** array-backed `ByteBuffer` reads and writes now operate directly on their backing arrays, and the Okio adapter no longer copies data back into the same scratch buffer.
- **Tiny forwarding buffer:** TCP forwarding now uses 64 KiB instead of 256 bytes and actively closes client sockets/ADB streams during shutdown.
- **Exceptional file-descriptor leaks:** File-based push, pull, install, and streaming install overloads now close their sources/sinks on both success and failure.

### Other reliability fixes

- Make sync close idempotent and always close the underlying ADB stream.
- Reject non-positive delayed-ACK credit.
- Reject empty split-install input and abandon package-manager sessions after write/commit failures.
- Require both a successful exit code and `Success` output for uninstall.
- Surface TCP forward bind failures immediately and clean up the executor.
- Roll back mDNS listeners/backends when startup registration fails.
- Remove the incompatible refreshVersions settings plugin and disable configuration cache for the current Kotlin 2.4 / Gradle 9.4 combination.
- Add opt-in delayed-ACK documentation.

## Local validation only

No GitHub Actions workflow was added or run.

- `gradle clean :kadb:jvmTest :kadb-mdns:jvmTest -PsignAllPublications=false --no-daemon`
  - **17 tests, 0 failures, 0 errors**
- `gradle build -PsignAllPublications=false --no-daemon`
  - **BUILD SUCCESSFUL; 49 actionable tasks**
  - Built JVM JARs and Android AARs.
- Synthetic delayed-ACK ADB peer:
  - transfers and byte-compares a 1 MiB payload;
  - deliberately withholds credit to verify that Kadb does not exceed the negotiated window.
- Resource tests cover failed push/pull descriptor cleanup, empty multi-install rejection, and immediate forward bind errors.

## Emulator status

Five opt-in emulator tests were added for shell/exec, push-pull/stat/list, forwarding, install/uninstall, and a 64 MiB transfer benchmark. They are excluded from ordinary JVM tests unless `KADB_EMULATOR_TESTS=1`.

Local Android 30 and 35 x86_64 images were attempted with multiple CPU/graphics configurations. This host exposes no `/dev/kvm`; software TCG did not reach a usable adbd session. Therefore these five emulator tests are **authored but not claimed as passed**.

## Remaining findings / follow-ups

1. **High — no resumable or atomic large-file upload:** a link drop restarts from byte zero and may leave a partial destination. Proposed follow-up: upload to a unique temporary path, verify size/hash, atomically rename; add chunk checkpoint/resume where the peer supports it.
2. **Medium — sync v2 compression flags are always zero:** compressible transfers cannot use zstd/lz4/brotli like newer adb clients. Proposed follow-up: negotiate codecs and benchmark CPU/network trade-offs.
3. **Medium — write timeout is not enforced by Android's blocking socket transport:** a dead peer can leave a write blocked. Proposed follow-up: cancellable NIO or a watchdog that closes the socket on deadline.
4. **Medium — lazy connection creation is not synchronized:** concurrent first use can race and create/leak more than one connection. Proposed follow-up: mutex/single-flight initialization.
5. **Medium — legacy ADB payload checksums are not validated:** corruption on old protocol versions may go undetected. Proposed follow-up: validate checksum before queueing messages.
6. **Low — package-manager fallback temporary APK names can collide:** concurrent installs of same-named APKs share a remote path. Proposed follow-up: per-install random directory/name.

The emulator gap is intentionally left visible in this Draft so it can be rerun locally on a KVM-capable Linux host or a physical device before marking the PR ready.